### PR TITLE
Fix attribute in ImportacionSearch

### DIFF
--- a/models/ImportacionSearch.php
+++ b/models/ImportacionSearch.php
@@ -75,7 +75,7 @@ class ImportacionSearch extends Importacion
             'cliente_id' => $this->cliente_id,
         ]);
 
-        $query->andFilterWhere(['like', 'nombre', $this->nombre])
+        $query->andFilterWhere(['like', 'importacion.nombre', $this->nombre])
             ->andFilterWhere(['like', 'apellido', $this->apellido])
             ->andFilterWhere(['like', 'telefono', $this->telefono])
             ->andFilterWhere(['like', 'celular', $this->celular])


### PR DESCRIPTION
Corregimos el problema producido al tener 2 atributos con el mismo nombre de atributo en una misma sentencia.
La correcion realizada, fue implementar en el prefijo del atributo el nombre de su modelo.